### PR TITLE
[APS-19255][APS-19256] fix: pin System.Net.Http 4.3.4 + System.Text.RegularExpressions 4.3.1

### DIFF
--- a/MSTest_browserstack/MSTest_browserstack.csproj
+++ b/MSTest_browserstack/MSTest_browserstack.csproj
@@ -16,6 +16,9 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="Selenium.WebDriver" Version="4.17.0" />
+    <!-- Security pins: override vulnerable transitive 4.3.0 (via NETStandard.Library 1.6.1). APS-19255 / APS-19256 -->
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Security Fix: APS-19255 + APS-19256

### Issue
Two High-severity (CVSS 7.5) GitHub advisories flagged on this repo:
- **APS-19255** — System.Net.Http .NET Core Information Disclosure ([GHSA-7jgj-8wvc-jh57](https://github.com/advisories/GHSA-7jgj-8wvc-jh57)), patched in 4.3.4
- **APS-19256** — System.Text.RegularExpressions Regex Denial of Service ([GHSA-cmhx-cq75-c4mj](https://github.com/advisories/GHSA-cmhx-cq75-c4mj)), patched in 4.3.1

### Root Cause
Both packages were present **transitively at the vulnerable 4.3.0** version, pulled in via the legacy `NETStandard.Library 1.6.1` meta-package (and `Serilog`/`System.Xml.ReaderWriter` for Regex) that the BrowserStack SDK dependency chain references. `dotnet list package --vulnerable --include-transitive` confirmed both as High on `main`. They are not direct references, so they cannot be removed by deleting a line — they must be overridden with an explicit pin.

### Fix Applied
Added two explicit `PackageReference` pins to the test `.csproj`, floating the transitive resolution up to the patched versions:
```xml
<PackageReference Include="System.Net.Http" Version="4.3.4" />
<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
```
This mirrors what Dependabot proposed (in two separate single-package PRs), combined into one. No application/source code changes.

### Testing
- `dotnet restore` + `dotnet build` succeed with 0 errors on the fix branch (net6.0).
- **`dotnet list package --vulnerable --include-transitive` after fix: "no vulnerable packages given the current sources"** (was 2 High before).
- Resolved versions confirmed: System.Net.Http = 4.3.4, System.Text.RegularExpressions = 4.3.1.

**BrowserStack Session Sanity**: BLOCKED (environment) — live `dotnet test` session could not be executed on the test machine: the BrowserStack .NET SDK test-host/driver could not launch (net6.0 runtime absent / Playwright browser driver not installed locally). This is an environment limitation, not a code issue. The change is dependency-metadata only (pins in csproj), builds cleanly, and is verified vulnerability-free via the dependency scanner.

### Jira Tickets
- https://browserstack.atlassian.net/browse/APS-19255
- https://browserstack.atlassian.net/browse/APS-19256

### Checklist
- [x] Security issue addressed (both advisories resolved per dependency scanner)
- [x] Build passing (restore + build, 0 errors)
- [ ] BrowserStack live session — blocked by local environment (see Testing)
- [x] Minimal change (csproj pins only)